### PR TITLE
Delete files and modified example

### DIFF
--- a/examples/pub-uni-bielefeld-de.fix
+++ b/examples/pub-uni-bielefeld-de.fix
@@ -19,13 +19,19 @@ join_field(bag.tags.DC-Identifier,' ')
 copy_field(rights,bag.tags.DC-Rights)
 join_field(bag.tags.DC-Rights,' ')
 
-# In Bielefeld PUB the fulltext download is the last identifier field
-copy_field(identifier.$last,bag.fetch.0.$append)
+# In Bielefeld PUB the fulltext download is contained in the identifier field
+# works for multiple files
+do list(path:identifier, var:loop)
+  if all_match(loop, 'download')
+    copy_field(loop,tmp.0)
+    copy_field(loop,tmp.1)
+    replace_all(tmp.1,'.*/','data/')
+    hash(tmp)
+    copy_field(tmp,bag.fetch.$append)
+    remove_field(tmp)
+  end
+end
 
-# For now we can only download one fulltext file using this technique
-copy_field(bag.fetch.0.0,bag.fetch.0.1)
-replace_all(bag.fetch.0.1,'.*/','data/')
-hash(bag.fetch.0)
 
 # Now we have all the data, delete the rest
 retain_field(bag)

--- a/lib/Catmandu/Exporter/BagIt.pm
+++ b/lib/Catmandu/Exporter/BagIt.pm
@@ -131,7 +131,7 @@ sub add {
             mkpath("$directory/data") unless -d "$directory/data";
 
             my $tmp = File::Temp->new(UNLINK => 1, suffix => '.tmp')
-              or Catmandu::Error->throw("Could not creat temp file");
+              or Catmandu::Error->throw("Could not create temp file");
 
             # For now using a simplistic mirror operation
             my $fname = $tmp->filename;

--- a/lib/Catmandu/Exporter/BagIt.pm
+++ b/lib/Catmandu/Exporter/BagIt.pm
@@ -143,7 +143,6 @@ sub add {
 
             $file =~ s{^data/}{};
             $bagit->add_file($file,IO::File->new($fname));
-            #$tmp->unlink_on_destroy(1);
             $bagit->write($directory, overwrite => 1);
             $tmp->unlink_on_destroy(1);
         }


### PR DESCRIPTION
This PR is related to #3. In version 0.10 the unlinking worked not correctly, I think. The example script still consumed a lot of disk space. After finishing, it tmp dir has been cleaned up. My changes forces the unlinking after very **record**.

And I have modified the example fix to work with multiple files, not only the last in the identifier field.
